### PR TITLE
feat: 🎸 테스트를 위한 Github Action Workflow 파일 추가

### DIFF
--- a/.github/workflows/test-before-integration.yml
+++ b/.github/workflows/test-before-integration.yml
@@ -1,0 +1,20 @@
+name: Test Before Integration
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package -file pom.xml -Dspring.profiles.active=dev


### PR DESCRIPTION
현재는 main으로 배포할 때만 CI가 일어나고 있어 develop 브랜치에 PR을 날렸을 때도 CI가 가능하게끔 간단한 Github action workflow를 작성하였습니다.